### PR TITLE
djangolondon.github.io -> www.djangolondon.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The official Github repo of The London Django Meetup Group.
 
 View the site at
-[http://djangolondon.github.io](http://djangolondon.github.io).
+[http://www.djangolondon.com](http://www.djangolondon.com).
 
 ## Contribution
 

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ description: >
     We meet on the 2nd Tuesday of every month to discuss Django, Python, the
     web, and related topics.
 baseurl: ''
-url: 'http://djangolondon.github.io'
+url: 'http://www.djangolondon.com'
 
 # Build settings
 markdown: kramdown

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -4,7 +4,7 @@ layout: default
 
 ## Be Awesome to Each Other
 
-The mission of [The London Django Meetup Group](http://djangolondon.github.io/)
+The mission of [The London Django Meetup Group](http://www.djangolondon.com/)
 is to provide fun, welcoming and professional environments so that diverse
 groups of people - regardless of age, race, gender identity or expression,
 background, disability, appearance, sexuality, walk of life, or religion - can


### PR DESCRIPTION
We're live on our own domain, fix the urls!