### PR TITLE
Fix permalink pattern

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,7 @@ url: 'http://www.djangolondon.com'
 
 # Build settings
 markdown: kramdown
+permalink: pretty
 exclude:
     - README.md
     - Gemfile


### PR DESCRIPTION
The url `code-of-conduct` isn't working on GH pages because it's generated as `code-of-conduct.html`, this wasn't spotted locally because jekyll serves `foo.html` at `foo` if no such directory exists.