### PR TITLE
Fix meetup template to use 'talks.size' rather than 'talks|size'

### DIFF
--- a/_layouts/meetup.html
+++ b/_layouts/meetup.html
@@ -24,7 +24,7 @@ layout: default
         {% endif %}
 
         <h2>Talks</h2>
-        {% if page.talks|size == 0 %}
+        {% if page.talks.size == 0 %}
         <h3>No Talks :(</h3>
         <p>Unfortunately this month there weren't any talks.</p>
         {% endif %}


### PR DESCRIPTION
Small syntax bug causing "No Talks :(" to always show up even when there are talks