### PR TITLE
New meetup.com URL

### DIFF
--- a/_meetups/2014-08-12.md
+++ b/_meetups/2014-08-12.md
@@ -2,7 +2,7 @@
 title: 'while true: beer() and django()'
 date: 2014-08-12 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/196782422/
+    meetup: http://www.meetup.com/djangolondon/events/196782422/
 talks:
 - title: Django at Scale
   speaker: Adam Johnson

--- a/_meetups/2015-06-09.md
+++ b/_meetups/2015-06-09.md
@@ -2,7 +2,7 @@
 title: Things I wish I'd known about Django
 date: 2015-06-09 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/222413498/
+    meetup: http://www.meetup.com/djangolondon/events/222413498/
     skills_matter: https://skillsmatter.com/meetups/7180-things-i-wish-i-d-known-about-django
 talks:
 - title: Django CMS best practices

--- a/_meetups/2015-07-14.md
+++ b/_meetups/2015-07-14.md
@@ -2,7 +2,7 @@
 title: The London Django pub meetup
 date: 2015-07-14 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/223297765/
+    meetup: http://www.meetup.com/djangolondon/events/223297765/
     skills_matter:
 talks:
 - title: Things I wish I'd known about Django

--- a/_meetups/2015-08-18.md
+++ b/_meetups/2015-08-18.md
@@ -2,7 +2,7 @@
 title: Better Python, better Django
 date: 2015-08-18 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/223938679/
+    meetup: http://www.meetup.com/djangolondon/events/223938679/
     skills_matter: https://skillsmatter.com/meetups/7248-london-django-august-2015-meetup
 talks:
 - title: Python 3 and Django

--- a/_meetups/2015-09-22.md
+++ b/_meetups/2015-09-22.md
@@ -2,7 +2,7 @@
 title: September Django Rain
 date: 2015-09-22 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/224716138/
+    meetup: http://www.meetup.com/djangolondon/events/224716138/
     skills_matter: https://skillsmatter.com/meetups/7311-september-django-rain
 talks:
 - title: Django Performance Recipes

--- a/_meetups/2015-12-14.md
+++ b/_meetups/2015-12-14.md
@@ -2,7 +2,7 @@
 title: December Django Meetup
 date: 2015-12-14 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/227021016/
+    meetup: http://www.meetup.com/djangolondon/events/227021016/
     skills_matter: https://skillsmatter.com/meetups/7611-django-lodnon-december-meetup
 talks:
 - title: Django on AWS

--- a/_meetups/2016-01-19.md
+++ b/_meetups/2016-01-19.md
@@ -2,7 +2,7 @@
 title: January Django Meetup
 date: 2016-01-19 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/227547663/
+    meetup: http://www.meetup.com/djangolondon/events/227547663/
     skills_matter: https://skillsmatter.com/meetups/7721-heroku-tour
 talks:
 - title: 'Factoryboy: Creating data for unit tests in an easy way'

--- a/_meetups/2016-02-16.md
+++ b/_meetups/2016-02-16.md
@@ -2,7 +2,7 @@
 title: Bring back the Django love
 date: 2016-02-16 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/228363107/
+    meetup: http://www.meetup.com/djangolondon/events/228363107/
     skills_matter: https://skillsmatter.com/meetups/7749-django-february-meetup
 talks:
 - title: How to build a cat website in 15 mins

--- a/_meetups/2016-03-15.md
+++ b/_meetups/2016-03-15.md
@@ -2,7 +2,7 @@
 title: Spring coding awaits!
 date: 2016-03-15 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/229282297/
+    meetup: http://www.meetup.com/djangolondon/events/229282297/
     skills_matter: https://skillsmatter.com/meetups/7877-django-march-meetup
 talks:
 - title: A brief introduction to Kubernetes

--- a/_meetups/2016-04-12.md
+++ b/_meetups/2016-04-12.md
@@ -2,7 +2,7 @@
 title: April Django Meetup
 date: 2016-04-12 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/230094002/
+    meetup: http://www.meetup.com/djangolondon/events/230094002/
     skills_matter: https://skillsmatter.com/meetups/8038-london-django-april-meetup
 talks:
 - title: Introduction and Djangocon EU Summary

--- a/_meetups/2016-05-10.md
+++ b/_meetups/2016-05-10.md
@@ -2,7 +2,7 @@
 title: "May Django Meetup"
 date: 2016-05-10 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/230447306/
+    meetup: http://www.meetup.com/djangolondon/events/230447306/
     skills_matter: https://skillsmatter.com/meetups/8043-london-django-may-meetup
 talks:
 - title: Django and Earthquakes

--- a/_meetups/2016-06-14.md
+++ b/_meetups/2016-06-14.md
@@ -2,7 +2,7 @@
 title: Django June Meetup
 date: 2016-06-14 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/231335519/
+    meetup: http://www.meetup.com/djangolondon/events/231335519/
     skills_matter: https://skillsmatter.com/meetups/8044-london-django-june-meetup
 talks:
 - title: How Django knows who you are

--- a/_meetups/2016-07-12.md
+++ b/_meetups/2016-07-12.md
@@ -2,7 +2,7 @@
 title: Django July Meetup - Coding Summer
 date: 2016-07-12 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/232245183/
+    meetup: http://www.meetup.com/djangolondon/events/232245183/
     skills_matter: https://skillsmatter.com/meetups/8045-london-django-july-meetup
 talks:
 - title: Untangling Django, Typescript and Angular 2

--- a/_meetups/2016-08-09.md
+++ b/_meetups/2016-08-09.md
@@ -2,7 +2,7 @@
 title: Django August Meetup
 date: 2016-08-09 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/232623366/
+    meetup: http://www.meetup.com/djangolondon/events/232623366/
     skills_matter: https://skillsmatter.com/meetups/8046-london-django-august-meetup
 talks:
 - title: Sharing Files Securely with Korra

--- a/_meetups/2016-09-13.md
+++ b/_meetups/2016-09-13.md
@@ -2,7 +2,7 @@
 title: Django September Meetup
 date: 2016-09-13 19:00:00 +0100
 links:
-    meetup: http://www.meetup.com/The-London-Django-Meetup-Group/events/233252435/
+    meetup: http://www.meetup.com/djangolondon/events/233252435/
     skills_matter: https://skillsmatter.com/meetups/8047-london-django-september-meetup
 talks:
 - title: Scaling task processing with Celery

--- a/_meetups/2016-10-11.md
+++ b/_meetups/2016-10-11.md
@@ -2,7 +2,7 @@
 title: Django October Meetup
 date: 2016-10-11 19:00:00 +0100
 links:
-    meetup: https://www.meetup.com/The-London-Django-Meetup-Group/events/234589043/
+    meetup: https://www.meetup.com/djangolondon/events/234589043/
     skills_matter: https://skillsmatter.com/meetups/8505-django-meetup
 talks:
 - title: Full clean factories

--- a/_meetups/2016-11-15.md
+++ b/_meetups/2016-11-15.md
@@ -2,7 +2,7 @@
 title: Django November Meetup
 date: 2016-11-15 19:00:00 +0100
 links:
-    meetup: https://www.meetup.com/The-London-Django-Meetup-Group/events/234853539/
+    meetup: https://www.meetup.com/djangolondon/events/234853539/
     skills_matter: https://skillsmatter.com/meetups/8541-london-django-meetup
 talks:
 - title: Database Gotchas - Two Key Concepts You Can't Afford to Ignore

--- a/_meetups/2016-12-13.md
+++ b/_meetups/2016-12-13.md
@@ -2,7 +2,7 @@
 title: December Django Meetup
 date: 2016-12-13 19:00:00 +0100
 links:
-    meetup: https://www.meetup.com/The-London-Django-Meetup-Group/events/235644842/
+    meetup: https://www.meetup.com/djangolondon/events/235644842/
     skills_matter: https://skillsmatter.com/meetups/8538-london-django-meetup
 talks:
 - title: FieldBuilder Snippet

--- a/_meetups/2017-01-10.md
+++ b/_meetups/2017-01-10.md
@@ -2,7 +2,7 @@
 title: January Django Meetup
 date: 2017-01-10 19:00:00 +0100
 links:
-    meetup: https://www.meetup.com/The-London-Django-Meetup-Group/events/236331645/
+    meetup: https://www.meetup.com/djangolondon/events/236331645/
     skills_matter: https://skillsmatter.com/meetups/8543-london-django-meetup
 talks: []
 ---

--- a/_meetups/2017-04-11.md
+++ b/_meetups/2017-04-11.md
@@ -2,7 +2,7 @@
 title: April Django Meetup
 date: 2017-04-11 19:00:00 +0100
 links:
-    meetup: https://www.meetup.com/The-London-Django-Meetup-Group/events/238464120/
+    meetup: https://www.meetup.com/djangolondon/events/238464120/
     skills_matter: https://skillsmatter.com/meetups/9144-london-django-april-meetup
 talks:
 - title: Introduction to JWT authentication

--- a/_meetups/2017-07-18.md
+++ b/_meetups/2017-07-18.md
@@ -2,7 +2,7 @@
 title: July Django Meetup
 date: 2017-07-18 19:00:00 +0100
 links:
-    meetup: https://www.meetup.com/The-London-Django-Meetup-Group/events/241141227/
+    meetup: https://www.meetup.com/djangolondon/events/241141227/
     skills_matter: https://skillsmatter.com/meetups/9671-london-django-july-meetup
 talks:
 - title: DjangoCon Europe 2017 Highlights

--- a/_meetups/2018-07-16.md
+++ b/_meetups/2018-07-16.md
@@ -2,7 +2,7 @@
 title: July Django Meetup
 date: 2018-07-16 19:00:00 +0100
 links:
-  meetup: https://www.meetup.com/The-London-Django-Meetup-Group/events/251911243/
+  meetup: https://www.meetup.com/djangolondon/events/251911243/
   skills_matter: https://skillsmatter.com/meetups/11175-london-django-july-meetup
 talks:
 - title:  Concurrency and Parallelism in Python- not as complicated as you think

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -49,7 +49,7 @@ session.
 We ask everyone to be aware that we will not tolerate intimidation, harassment,
 or any abusive, discriminatory, or derogatory behaviour by anyone at any event,
 or online. Complaints can be made to the [meetup
-organisers](http://www.meetup.com/The-London-Django-Meetup-Group/members/?op=leaders)
+organisers](http://www.meetup.com/djangolondon/members/?op=leaders)
 either face to face at a meetup, or via the Meetup website. Any complaints
 made to event organisers will remain confidential, be taken seriously, and
 be treated appropriately with discretion. Should an event organiser consider
@@ -90,9 +90,9 @@ examples of behaviours which are not appropriate:
 
 If you're not sure about anything you've just read please contact the
 [Meetup
-organisers](http://www.meetup.com/The-London-Django-Meetup-Group/members/?op=leaders).
+organisers](http://www.meetup.com/djangolondon/members/?op=leaders).
 You can message us through the [Meetup
-page](http://www.meetup.com/The-London-Django-Meetup-Group/).
+page](http://www.meetup.com/djangolondon/).
 
 ## Credits
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ layout: default
     <p>Visit us at:</p>
 
     <ul>
-        <li><a href="http://www.meetup.com/The-London-Django-Meetup-Group/">Meetup.com</a></li>
+        <li><a href="http://www.meetup.com/djangolondon/">Meetup.com</a></li>
         <li><a href="https://skillsmatter.com/groups/10546-london-django-meetup-group">Skills Matter</a></li>
         <li><a href="https://londondjangomeetup.herokuapp.com/">Slack</a></li>
         <li><a href="https://github.com/djangolondon/">Github</a></li>


### PR DESCRIPTION
I've changed our meetup.com URL as the old one was a bit unwieldy. It now matches our domain, GitHub and Twitter. The old one (meetup.com/The-London-Django-Meetup-Group) redirects to the new one (meetup.com/djangolondon).